### PR TITLE
Reference to database container

### DIFF
--- a/tests/e2e/docker-compose.yml
+++ b/tests/e2e/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     environment:
       MESSAGE_BROKER_ADDRESS: rabbitmq
       DATABASE_PORT_OVERRIDE: 5432
-      DATABASE_HOST_OVERRIDE: database
+      DATABASE_HOST_OVERRIDE: storage
       GOB_SHARED_DIR: /app/shared
     volumes:
       - gob-volume:/app/shared
@@ -40,7 +40,7 @@ services:
       - "8141:8000"
     environment:
       DATABASE_PORT_OVERRIDE: 5432
-      DATABASE_HOST_OVERRIDE: database
+      DATABASE_HOST_OVERRIDE: storage
       UWSGI_HTTP: ":8000"
       UWSGI_MODULE: "gobapi.wsgi"
       UWSGI_CALLABLE: "application"


### PR DESCRIPTION
The name of the database container should be storage
instead of database