### PR TITLE
Remove airflow database from GOB Infra

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,18 +33,6 @@ services:
     volumes:
     - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
 
-  airflow_database:
-    image: amsterdam/postgres
-    ports:
-    - "5409:5432"
-    container_name: airflow_database
-    environment:
-      POSTGRES_PASSWORD: insecure
-      POSTGRES_DB: airflow
-      POSTGRES_USER: gob
-    volumes:
-    - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
-
 volumes:
   gob-volume:
     external: true


### PR DESCRIPTION
This database is airflow specific and not related to or part of GOB